### PR TITLE
Implement Contig and error

### DIFF
--- a/src/contig.rs
+++ b/src/contig.rs
@@ -1,12 +1,7 @@
 use std::cmp::Ordering;
-use std::fmt::{Debug, Error};
-use std::string::ParseError;
+use std::fmt::Debug;
 
-use self::err::SvartError;
-
-// ------------------------------------------- CONTIG ----------------------------------------------
-// TODO - require implementation of PartialOrd
-pub trait Contig {
+pub trait Contig: PartialOrd {
     fn id(&self) -> usize;
     fn name(&self) -> &str;
     fn sequence_role(&self) -> &SequenceRole;
@@ -18,111 +13,7 @@ pub trait Contig {
     fn ucsc_name(&self) -> &str;
 }
 
-// ----------------------------------- DEFAULT CONTIG ----------------------------------------------
-
 #[derive(Debug)]
-pub struct ContigDefault {
-    id: usize,
-    name: String,
-    sequence_role: SequenceRole,
-    assigned_molecule: String,
-    assigned_molecule_type: AssignedMoleculeType,
-    length: usize,
-    gen_bank_accession: String,
-    ref_seq_accession: String,
-    ucsc_name: String,
-}
-
-impl ContigDefault {
-    pub fn of(
-        id: usize,
-        name: String,
-        sequence_role: SequenceRole,
-        assigned_molecule: String,
-        assigned_molecule_type: AssignedMoleculeType,
-        length: usize,
-        gen_bank_accession: String,
-        ref_seq_accession: String,
-        ucsc_name: String) -> Result<ContigDefault, SvartError> {
-        if id == 0 {
-            return Err(SvartError::IllegalValueError("Id 0 is reserved for the unknown contig".to_string()));
-        }
-
-        Ok(ContigDefault {
-            id,
-            name,
-            sequence_role,
-            assigned_molecule,
-            assigned_molecule_type,
-            length,
-            gen_bank_accession,
-            ref_seq_accession,
-            ucsc_name,
-        })
-    }
-}
-
-impl Contig for ContigDefault {
-    fn id(&self) -> usize {
-        self.id
-    }
-
-    fn name(&self) -> &str {
-        self.name.as_str()
-    }
-
-    fn sequence_role(&self) -> &SequenceRole {
-        &self.sequence_role
-    }
-
-    fn assigned_molecule(&self) -> &str {
-        self.assigned_molecule.as_str()
-    }
-
-    fn assigned_molecule_type(&self) -> &AssignedMoleculeType {
-        &self.assigned_molecule_type
-    }
-
-    fn length(&self) -> usize {
-        self.length
-    }
-
-    fn gen_bank_accession(&self) -> &str {
-        self.gen_bank_accession.as_str()
-    }
-
-    fn ref_seq_accession(&self) -> &str {
-        self.ref_seq_accession.as_str()
-    }
-
-    fn ucsc_name(&self) -> &str {
-        self.ucsc_name.as_str()
-    }
-}
-
-impl<T: Contig> PartialEq<T> for ContigDefault {
-    fn eq(&self, other: &T) -> bool {
-        self.id == other.id()
-            && self.name() == other.name()
-            && self.sequence_role() == other.sequence_role()
-            && self.assigned_molecule() == other.assigned_molecule()
-            && self.assigned_molecule_type() == other.assigned_molecule_type()
-            && self.length() == other.length()
-            && self.gen_bank_accession() == other.gen_bank_accession()
-            && self.ref_seq_accession() == other.ref_seq_accession()
-            && self.ucsc_name() == other.ucsc_name()
-    }
-}
-
-impl<T: Contig> PartialOrd<T> for ContigDefault {
-    fn partial_cmp(&self, other: &T) -> Option<Ordering> {
-        self.id.partial_cmp(&other.id())
-    }
-}
-
-// ----------------------------------- UNKNOWN CONTIG ----------------------------------------------
-
-#[derive(Debug, PartialEq)]
 pub struct UnknownContig {
     id: usize,
     name: &'static str,
@@ -173,7 +64,17 @@ impl Contig for UnknownContig {
     }
 }
 
-// TODO - PartialEq, PartialOrd for UnknownContig
+impl<T: Contig> PartialEq<T> for UnknownContig {
+    fn eq(&self, other: &T) -> bool {
+        self.id() == other.id()
+    }
+}
+
+impl<T: Contig> PartialOrd<T> for UnknownContig {
+    fn partial_cmp(&self, other: &T) -> Option<Ordering> {
+        self.id().partial_cmp(&other.id())
+    }
+}
 
 // singleton UnknownContig
 const UNKNOWN_CONTIG: UnknownContig = UnknownContig {
@@ -250,50 +151,9 @@ impl AssignedMoleculeType {
 
 #[cfg(test)]
 mod test {
+    use crate::default::ContigDefault;
+
     use super::*;
-
-    // These are just SOME and not necessarily all tests
-
-    #[test]
-    fn test_default_contig() {
-        let contig = ContigDefault::of(
-            1,
-            "1".to_string(),
-            SequenceRole::AssembledMolecule,
-            "1".to_string(),
-            AssignedMoleculeType::Chromosome,
-            249_250_621,
-            "CM000663.1".to_string(),
-            "NC_000001.10".to_string(),
-            "chr1".to_string());
-        assert!(contig.is_ok());
-
-        let contig = contig.unwrap();
-        assert_eq!(contig.id(), 1);
-        assert_eq!(contig.name(), "1");
-        assert_eq!(contig.sequence_role(), &SequenceRole::AssembledMolecule);
-        assert_eq!(contig.assigned_molecule(), "1");
-        assert_eq!(contig.assigned_molecule_type(), &AssignedMoleculeType::Chromosome);
-        assert_eq!(contig.gen_bank_accession(), "CM000663.1");
-        assert_eq!(contig.ref_seq_accession(), "NC_000001.10");
-        assert_eq!(contig.ucsc_name(), "chr1");
-    }
-
-    #[test]
-    fn test_contig_from_bad_id() {
-        let contig = ContigDefault::of(
-            0,
-            "1".to_string(),
-            SequenceRole::AssembledMolecule,
-            "1".to_string(),
-            AssignedMoleculeType::Chromosome,
-            249_250_621,
-            "CM000663.1".to_string(),
-            "NC_000001.10".to_string(),
-            "chr1".to_string());
-        assert!(contig.is_err());
-        assert_eq!(contig.err().unwrap().to_string(), "Illegal value error: id 0 is reserved for the unknown contig".to_string())
-    }
 
     #[test]
     fn test_unknown_contig() {
@@ -311,5 +171,39 @@ mod test {
         assert_eq!(contig.gen_bank_accession(), "");
         assert_eq!(contig.ref_seq_accession(), "");
         assert_eq!(contig.ucsc_name(), "na");
+    }
+
+    #[test]
+    fn test_eq() {
+        let one = unknown_contig();
+        let two = unknown_contig();
+        assert_eq!(one, two);
+
+        let other = get_contig();
+        assert_ne!(one, &other);
+    }
+
+    #[test]
+    fn test_cmp() {
+        let one = unknown_contig();
+        let two = unknown_contig();
+        assert_eq!(one, two);
+
+        let other = get_contig();
+        assert_eq!(one, two);
+        assert!(!(one > two));
+        assert!(!(one < two));
+        assert!(one < &other);
+        assert!(&other > one);
+    }
+
+    fn get_contig() -> ContigDefault {
+        ContigDefault::of(1, "1".to_string(),
+                          SequenceRole::AssembledMolecule, "1".to_string(),
+                          AssignedMoleculeType::Chromosome, 249_250_621,
+                          "CM000663.1".to_string(),
+                          "NC_000001.10".to_string(),
+                          "chr1".to_string())
+            .unwrap()
     }
 }

--- a/src/default/contig.rs
+++ b/src/default/contig.rs
@@ -1,0 +1,175 @@
+use std::cmp::Ordering;
+
+use crate::contig::{AssignedMoleculeType, Contig, SequenceRole};
+use crate::err::SvartError;
+
+#[derive(Debug)]
+pub struct ContigDefault {
+    id: usize,
+    name: String,
+    sequence_role: SequenceRole,
+    assigned_molecule: String,
+    assigned_molecule_type: AssignedMoleculeType,
+    length: usize,
+    gen_bank_accession: String,
+    ref_seq_accession: String,
+    ucsc_name: String,
+}
+
+impl ContigDefault {
+    pub fn of(id: usize,
+              name: String,
+              sequence_role: SequenceRole,
+              assigned_molecule: String,
+              assigned_molecule_type: AssignedMoleculeType,
+              length: usize,
+              gen_bank_accession: String,
+              ref_seq_accession: String,
+              ucsc_name: String) -> Result<ContigDefault, SvartError> {
+        if id == 0 {
+            return Err(SvartError::IllegalValueError("Id 0 is reserved for the unknown contig".to_string()));
+        }
+
+        Ok(ContigDefault {
+            id,
+            name,
+            sequence_role,
+            assigned_molecule,
+            assigned_molecule_type,
+            length,
+            gen_bank_accession,
+            ref_seq_accession,
+            ucsc_name,
+        })
+    }
+}
+
+impl Contig for ContigDefault {
+    fn id(&self) -> usize {
+        self.id
+    }
+
+    fn name(&self) -> &str {
+        self.name.as_str()
+    }
+
+    fn sequence_role(&self) -> &SequenceRole {
+        &self.sequence_role
+    }
+
+    fn assigned_molecule(&self) -> &str {
+        self.assigned_molecule.as_str()
+    }
+
+    fn assigned_molecule_type(&self) -> &AssignedMoleculeType {
+        &self.assigned_molecule_type
+    }
+
+    fn length(&self) -> usize {
+        self.length
+    }
+
+    fn gen_bank_accession(&self) -> &str {
+        self.gen_bank_accession.as_str()
+    }
+
+    fn ref_seq_accession(&self) -> &str {
+        self.ref_seq_accession.as_str()
+    }
+
+    fn ucsc_name(&self) -> &str {
+        self.ucsc_name.as_str()
+    }
+}
+
+impl<T: Contig> PartialEq<T> for ContigDefault {
+    fn eq(&self, other: &T) -> bool {
+        self.id == other.id()
+            && self.name() == other.name()
+            && self.sequence_role() == other.sequence_role()
+            && self.assigned_molecule() == other.assigned_molecule()
+            && self.assigned_molecule_type() == other.assigned_molecule_type()
+            && self.length() == other.length()
+            && self.gen_bank_accession() == other.gen_bank_accession()
+            && self.ref_seq_accession() == other.ref_seq_accession()
+            && self.ucsc_name() == other.ucsc_name()
+    }
+}
+
+impl<T: Contig> PartialOrd<T> for ContigDefault {
+    fn partial_cmp(&self, other: &T) -> Option<Ordering> {
+        self.id.partial_cmp(&other.id())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_default_contig() {
+        let contig = get_contig();
+        assert!(contig.is_ok());
+
+        let contig = contig.unwrap();
+        assert_eq!(contig.id(), 1);
+        assert_eq!(contig.name(), "1");
+        assert_eq!(contig.sequence_role(), &SequenceRole::AssembledMolecule);
+        assert_eq!(contig.assigned_molecule(), "1");
+        assert_eq!(contig.assigned_molecule_type(), &AssignedMoleculeType::Chromosome);
+        assert_eq!(contig.gen_bank_accession(), "CM000663.1");
+        assert_eq!(contig.ref_seq_accession(), "NC_000001.10");
+        assert_eq!(contig.ucsc_name(), "chr1");
+    }
+
+    #[test]
+    fn test_contig_from_bad_id() {
+        let contig = ContigDefault::of(
+            0,
+            "1".to_string(),
+            SequenceRole::AssembledMolecule,
+            "1".to_string(),
+            AssignedMoleculeType::Chromosome,
+            249_250_621,
+            "CM000663.1".to_string(),
+            "NC_000001.10".to_string(),
+            "chr1".to_string());
+        assert!(contig.is_err());
+        assert_eq!(contig.err().unwrap().to_string(), "Illegal value error: Id 0 is reserved for the unknown contig".to_string())
+    }
+
+    #[test]
+    fn test_eq() {
+        let one = get_contig().unwrap();
+        let two = get_contig().unwrap();
+        assert_eq!(one, two);
+    }
+
+    #[test]
+    fn test_cmp() {
+        let one = get_contig().unwrap();
+        let two = ContigDefault::of(2, "2".to_string(),
+                                    SequenceRole::AssembledMolecule, "2".to_string(),
+            AssignedMoleculeType::Chromosome,
+            123_456,
+            "".to_string(),
+            "".to_string(),
+            "".to_string()).unwrap();
+        assert_ne!(one, two);
+        assert!(one < two);
+        assert!(two > one);
+    }
+
+    fn get_contig() -> Result<ContigDefault, SvartError> {
+        ContigDefault::of(
+            1,
+            "1".to_string(),
+            SequenceRole::AssembledMolecule,
+            "1".to_string(),
+            AssignedMoleculeType::Chromosome,
+            249_250_621,
+            "CM000663.1".to_string(),
+            "NC_000001.10".to_string(),
+            "chr1".to_string())
+    }
+}

--- a/src/default/mod.rs
+++ b/src/default/mod.rs
@@ -1,0 +1,3 @@
+mod contig;
+
+pub use contig::ContigDefault;

--- a/src/err.rs
+++ b/src/err.rs
@@ -1,4 +1,3 @@
-use std::any::TypeId;
 use std::error::Error;
 use std::fmt::{Display, Formatter};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@ mod bound;
 mod coordinate_system;
 mod contig;
 mod err;
+mod default;
 
 // TODO - think about API structure
 pub use self::bound::*;


### PR DESCRIPTION
Implement:
- `Contig` trait, `UnknownContig`, and the default implementation
- `SvartError`

Addresses #8 and #6 